### PR TITLE
Default region s3 repository should be eu-west-1 instead of EU

### DIFF
--- a/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -110,9 +110,9 @@ public class S3Repository extends BlobStoreRepository {
                 } else if ("ap-northeast-1".equals(regionSetting)) {
                     region = "ap-northeast-1";
                 } else if ("eu-west".equals(regionSetting)) {
-                    region = "EU";
+                    region = "eu-west-1";
                 } else if ("eu-west-1".equals(regionSetting)) {
-                    region = "EU";
+                    region = "eu-west-1";
                 } else if ("eu-central".equals(regionSetting)) {
                     region = "eu-central-1";
                 } else if ("eu-central-1".equals(regionSetting)) {


### PR DESCRIPTION
Fix for region settings for s3 snapshot reposirotyr in eu-west-1. Right now, if you don't explicitly set region in request creating repository, it's set to default 'EU' for which s3 endpoint discovery can't find right endpoint. 