### PR TITLE
Remove an excess quote character in an exception message

### DIFF
--- a/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStore.java
+++ b/src/main/java/org/elasticsearch/cloud/aws/blobstore/S3BlobStore.java
@@ -67,7 +67,7 @@ public class S3BlobStore extends AbstractComponent implements BlobStore {
 
         this.bufferSize = (bufferSize != null) ? bufferSize : MIN_BUFFER_SIZE;
         if (this.bufferSize.getBytes() < MIN_BUFFER_SIZE.getBytes()) {
-            throw new BlobStoreException("\"Detected a buffer_size for the S3 storage lower than [" + MIN_BUFFER_SIZE + "]");
+            throw new BlobStoreException("Detected a buffer_size for the S3 storage lower than [" + MIN_BUFFER_SIZE + "]");
         }
 
         this.numberOfRetries = maxRetries;


### PR DESCRIPTION
This fixes the weird quote below:
~~~~
[2015-02-10 16:56:28,701][WARN ][repositories             ] [Plug] failed to create repository [s3][collaborne-data-s3-test]
org.elasticsearch.common.inject.CreationException: Guice creation errors:

1) Error injecting constructor, org.elasticsearch.common.blobstore.BlobStoreException: "Detected a buffer_size for the S3 storage lower than [5mb]
  at org.elasticsearch.repositories.s3.S3Repository.<init>(Unknown Source)
  while locating org.elasticsearch.repositories.s3.S3Repository
  while locating org.elasticsearch.repositories.Repository

1 error
	at org.elasticsearch.common.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:344)
	at org.elasticsearch.common.inject.InjectorBuilder.injectDynamically(InjectorBuilder.java:178)
	at org.elasticsearch.common.inject.InjectorBuilder.build(InjectorBuilder.java:110)
	at org.elasticsearch.common.inject.InjectorImpl.createChildInjector(InjectorImpl.java:131)
	at org.elasticsearch.common.inject.ModulesBuilder.createChildInjector(ModulesBuilder.java:69)
	at org.elasticsearch.repositories.RepositoriesService.createRepositoryHolder(RepositoriesService.java:395)
	at org.elasticsearch.repositories.RepositoriesService.registerRepository(RepositoriesService.java:356)
	at org.elasticsearch.repositories.RepositoriesService.access$100(RepositoriesService.java:55)
	at org.elasticsearch.repositories.RepositoriesService$1.execute(RepositoriesService.java:110)
	at org.elasticsearch.cluster.service.InternalClusterService$UpdateTask.run(InternalClusterService.java:329)
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:153)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.elasticsearch.common.blobstore.BlobStoreException: "Detected a buffer_size for the S3 storage lower than [5mb]
	at org.elasticsearch.cloud.aws.blobstore.S3BlobStore.<init>(S3BlobStore.java:70)
	at org.elasticsearch.repositories.s3.S3Repository.<init>(S3Repository.java:130)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:408)
	at org.elasticsearch.common.inject.DefaultConstructionProxyFactory$1.newInstance(DefaultConstructionProxyFactory.java:54)
	at org.elasticsearch.common.inject.ConstructorInjector.construct(ConstructorInjector.java:86)
	at org.elasticsearch.common.inject.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:98)
	at org.elasticsearch.common.inject.FactoryProxy.get(FactoryProxy.java:52)
	at org.elasticsearch.common.inject.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:45)
	at org.elasticsearch.common.inject.InjectorImpl.callInContext(InjectorImpl.java:837)
	at org.elasticsearch.common.inject.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:42)
	at org.elasticsearch.common.inject.Scopes$1$1.get(Scopes.java:57)
	at org.elasticsearch.common.inject.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45)
	at org.elasticsearch.common.inject.InjectorBuilder$1.call(InjectorBuilder.java:200)
	at org.elasticsearch.common.inject.InjectorBuilder$1.call(InjectorBuilder.java:193)
	at org.elasticsearch.common.inject.InjectorImpl.callInContext(InjectorImpl.java:830)
	at org.elasticsearch.common.inject.InjectorBuilder.loadEagerSingletons(InjectorBuilder.java:193)
	at org.elasticsearch.common.inject.InjectorBuilder.injectDynamically(InjectorBuilder.java:175)
	... 12 more
~~~~