### PR TITLE
PUBLIC_IP was using Public Dns Name

### DIFF
--- a/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2UnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2UnicastHostsProvider.java
@@ -153,7 +153,7 @@ public class AwsEc2UnicastHostsProvider extends AbstractComponent implements Uni
                         address = instance.getPublicDnsName();
                         break;
                     case PUBLIC_IP:
-                        address = instance.getPublicDnsName();
+                        address = instance.getPublicIpAddress();
                         break;
                 }
                 if (address != null) {


### PR DESCRIPTION
It looks like bug and can be related to issue https://github.com/elasticsearch/elasticsearch-cloud-aws/issues/76